### PR TITLE
Give DictNode default instance access to parent and context

### DIFF
--- a/configyaml/config/dict.py
+++ b/configyaml/config/dict.py
@@ -43,7 +43,7 @@ class DictNode(AbstractNode):
         for k, v in self._dict_fields.items():
             if 'default' in v:
                 default = v['default']
-                instance = v['class'](value=default)
+                instance = v['class'](value=default, context=self._context, parent=self)
                 self.__dict__[k] = instance
                 self._children[k] = instance
 

--- a/configyaml/config/dict.py
+++ b/configyaml/config/dict.py
@@ -43,7 +43,7 @@ class DictNode(AbstractNode):
         for k, v in self._dict_fields.items():
             if 'default' in v:
                 default = v['default']
-                instance = v['class'](value=default, context=self._context, parent=self)
+                instance = v['class'](value=default, context=self._context, key=k, parent=self)
                 self.__dict__[k] = instance
                 self._children[k] = instance
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -104,11 +104,13 @@ def test_default():
     config = DummyConfigDefault(value=value)
     assert config.is_valid()
     assert config.foo._value == 'test'
+    assert config.foo._parent == config
 
     value = {'foo': 'bar'}
     config = DummyConfigDefault(value=value)
     assert config.is_valid()
     assert config.foo._value == 'bar'
+    assert config.foo._parent == config
 
 
 def test_get_item():

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -105,12 +105,14 @@ def test_default():
     assert config.is_valid()
     assert config.foo._value == 'test'
     assert config.foo._parent == config
+    assert config.foo._key == 'foo'
 
     value = {'foo': 'bar'}
     config = DummyConfigDefault(value=value)
     assert config.is_valid()
     assert config.foo._value == 'bar'
     assert config.foo._parent == config
+    assert config.foo._key == 'foo'
 
 
 def test_get_item():


### PR DESCRIPTION
I don't think this should cause any issues... Basically, I was working in a situation where I wanted to use the `_parent` reference to traverse back up the config to get some data, and realized that if that node was created using a default value, then I didn't have access to the parent and some other data that I think should still be relevant. Now the only thing it doesn't have that a non-default usage has is the `_value_node`, which I think makes sense because that would be the YAML node which woudn't exist here, because that field wasn't in the YAML. 