### PR TITLE
Add support for variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/configyaml/config/base.py
+++ b/configyaml/config/base.py
@@ -27,6 +27,8 @@ class AbstractNode(object):
         self._parent = parent
         self._errors = []
 
+        self._is_variable = isinstance(self._original_value, str) and self._original_value.startswith('$')
+
         self._value = self._render_value(self._original_value)
 
         if self._errors:
@@ -50,7 +52,7 @@ class AbstractNode(object):
         return not self._errors
 
     def _render_value(self, value):
-        if self._variables and isinstance(value, str) and value.startswith('$'):
+        if self._is_variable:
             if not isinstance(self._variables, dict):
                 raise TypeError('variables must be a dict')
 
@@ -61,7 +63,8 @@ class AbstractNode(object):
             else:
                 self._add_error(
                     title='Variable not found',
-                    description='\'{}\' was not found in {}'.format(variable_name, list(self._variables.keys()))
+                    # it is safe to give the keys of the variables, but not values
+                    description='\'{}\' was not found in {}'.format(variable_name, sorted(list(self._variables.keys())))
                 )
 
         elif isinstance(value, str) and value.startswith('\$'):
@@ -181,13 +184,33 @@ class AbstractNode(object):
         """An optional dictionary of context to be injected into children"""
         return {}
 
-    def _as_dict_to_inject(self):  # type: () -> dict
+    def _as_dict_to_inject(self, redact=False):  # type: () -> dict
         """Additional fields to inject into as_dict"""
         return {}
 
-    def _as_dict(self):  # type: () -> dict
-        d = {'value': self._value}
+    def _as_dict(self, redact=False):  # type: () -> dict
+        if redact and self._should_redact():
+            return self._as_redacted_dict()
+
+        d = {}
+        d['value'] = self._value
         if self._errors:
             d['errors'] = [x.as_dict() for x in self._errors]
-        d.update(self._as_dict_to_inject())
+        d.update(self._as_dict_to_inject(redact=redact))
+        return d
+
+    def _should_redact(self):
+        return self._is_variable and self._value != self._original_value
+
+    def _as_redacted_dict(self):
+        d = {}
+
+        d['value'] = '[REDACTED]'
+        d['redacted'] = True
+
+        if self._errors:
+            d['errors'] = [x.as_dict() for x in self._errors]
+
+        d.update(self._as_dict_to_inject(redact=True))
+
         return d

--- a/configyaml/config/base.py
+++ b/configyaml/config/base.py
@@ -113,6 +113,8 @@ class AbstractNode(object):
     def _add_error(self, *args, **kwargs):  # type: () -> None
         """Convenience function to add an error to this object, with line numbers
 
+        An error title or description should not accidentally leak self._value, for privacy/redaction purposes.
+
         :rtype: None
         """
         if kwargs.get('node', None):

--- a/configyaml/config/dict.py
+++ b/configyaml/config/dict.py
@@ -16,7 +16,14 @@ class DictNode(AbstractNode):
             if key in self._dict_fields:
                 # get class for key
                 field_class = self._dict_fields[key]['class']
-                field = field_class(value=self._value[key], value_node=self._find_node_for_key_value(key), context=self._context, key=key, parent=self)
+                field = field_class(
+                    value=self._value[key],
+                    value_node=self._find_node_for_key_value(key),
+                    context=self._context,
+                    variables=self._variables,
+                    key=key,
+                    parent=self
+                )
 
                 # set self.FIELD_NAME so we can get children directly
                 # these will only be keys we specify, so should be safe names
@@ -43,7 +50,13 @@ class DictNode(AbstractNode):
         for k, v in self._dict_fields.items():
             if 'default' in v:
                 default = v['default']
-                instance = v['class'](value=default, context=self._context, key=k, parent=self)
+                instance = v['class'](
+                    value=default,
+                    context=self._context,
+                    variables=self._variables,
+                    key=k,
+                    parent=self
+                )
                 self.__dict__[k] = instance
                 self._children[k] = instance
 

--- a/configyaml/config/dict.py
+++ b/configyaml/config/dict.py
@@ -91,14 +91,17 @@ class DictNode(AbstractNode):
     def __len__(self):
         return len(self._children)
 
-    def _as_dict(self):
+    def _as_dict(self, redact=False):
+        if redact and self._should_redact():
+            return self._as_redacted_dict()
+
         d = {}
         for k in self._dict_fields.keys():
-            d[k] = self[k]._as_dict()
+            d[k] = self[k]._as_dict(redact=redact)
 
         if self._errors:
             d['errors'] = [x.as_dict() for x in self._errors]
 
-        d.update(self._as_dict_to_inject())
+        d.update(self._as_dict_to_inject(redact=redact))
 
         return d

--- a/configyaml/config/list.py
+++ b/configyaml/config/list.py
@@ -42,6 +42,13 @@ class ListNode(AbstractNode):
         if not self._value_node:
             return None
 
+        if not isinstance(self._value_node, self._type):
+            # the original node was not a list
+            # - could have been a variable string
+            #
+            # return the original node so that the yaml text can place the error there
+            return self._value_node
+
         return self._value_node.value[index]
 
     def __getitem__(self, key):
@@ -50,13 +57,16 @@ class ListNode(AbstractNode):
     def __len__(self):
         return len(self._children)
 
-    def _as_dict(self):
+    def _as_dict(self, redact=False):
+        if redact and self._should_redact():
+            return self._as_redacted_dict()
+
         d = {
-            'items': [x._as_dict() for x in self._children],
+            'items': [x._as_dict(redact=redact) for x in self._children],
         }
 
         if self._errors:
             d['errors'] = [x.as_dict() for x in self._errors]
 
-        d.update(self._as_dict_to_inject())
+        d.update(self._as_dict_to_inject(redact=redact))
         return d

--- a/configyaml/config/list.py
+++ b/configyaml/config/list.py
@@ -27,7 +27,14 @@ class ListNode(AbstractNode):
 
         for index, item in enumerate(self._value):
             field_class = self._list_item_class
-            field = field_class(value=item, value_node=self._find_node_for_list_index(index), context=self._context, parent=self, key=index)
+            field = field_class(
+                value=item,
+                value_node=self._find_node_for_list_index(index),
+                context=self._context,
+                variables=self._variables,
+                parent=self,
+                key=index
+            )
 
             self._children.append(field)
 

--- a/configyaml/config/nodes.py
+++ b/configyaml/config/nodes.py
@@ -35,15 +35,18 @@ class WildcardDictNode(DictNode):
                     description=explanation
                 )
 
-    def _as_dict(self):
+    def _as_dict(self, redact=False):
+        if redact and self._should_redact():
+            return self._as_redacted_dict()
+
         d = {}
         for group_name in self._children.keys():
-            d[group_name] = self[group_name]._as_dict()
+            d[group_name] = self[group_name]._as_dict(redact=redact)
 
         if self._errors:
             d['errors'] = [x.as_dict() for x in self._errors]
 
-        d.update(self._as_dict_to_inject())
+        d.update(self._as_dict_to_inject(redact=redact))
 
         return d
 

--- a/configyaml/config/nodes.py
+++ b/configyaml/config/nodes.py
@@ -17,8 +17,14 @@ class WildcardDictNode(DictNode):
             key_valid, explanation = self._key_name_is_valid(key)
             if key_valid:
                 field_class = self._dict_fields['*']['class']
-                field = field_class(value=value, value_node=self._find_node_for_key_value(key),
-                                    context=self._context, key=key, parent=self)
+                field = field_class(
+                    value=value,
+                    value_node=self._find_node_for_key_value(key),
+                    context=self._context,
+                    variables=self._variables,
+                    key=key,
+                    parent=self
+                )
 
                 # don't set __dict__ if they can use any key
                 self._children[key] = field

--- a/configyaml/config/nodes.py
+++ b/configyaml/config/nodes.py
@@ -98,8 +98,7 @@ class PositiveIntegerNode(IntegerNode):
     """A node that must validate as a positive integer"""
     def _validate_value(self):
         if self._value < 0:
-            description = "{value} must be a positive integer".format(value=self._value)
-            self._add_error(title="Invalid Value", description=description)
+            self._add_error(title="Invalid Value", description="Must be a positive integer")
 
 
 class TypelessNode(AbstractNode):

--- a/configyaml/loader.py
+++ b/configyaml/loader.py
@@ -68,10 +68,10 @@ class ConfigLoader(object):
         # just pass off as dict right now
         return self.config_dict[key]
 
-    def as_dict(self):
+    def as_dict(self, redact=False):
         d = {
             'config_text': self.config_text,
-            'config': self.config_root._as_dict() if self.config_root else None,
+            'config': self.config_root._as_dict(redact=redact) if self.config_root else None,
         }
         if self.errors:
             d['errors'] = [x.as_dict() for x in self.errors]

--- a/configyaml/loader.py
+++ b/configyaml/loader.py
@@ -7,14 +7,15 @@ from .errors import ConfigError
 class ConfigLoader(object):
     config_root_class = None
 
-    def __init__(self, config_text, context={}, *args, **kwargs):
+    def __init__(self, config_text, context={}, variables={}):
         if not self.config_root_class:
             raise AttributeError('config_root_class must defined in subclasses of ConfigLoader')
 
         self.config_text = config_text
         self.config_dict = None
         self.config_root = None
-        self.variable_context = context
+        self.context = context
+        self.variables = variables
 
         self._errors = []
         self.load()
@@ -46,7 +47,12 @@ class ConfigLoader(object):
             # we have valid yaml with data, so start checking the components
             node_tree = yaml.compose(self.config_text)
             # give it the parsed settings, and the node info
-            self.config_root = self.config_root_class(value=self.config_dict, value_node=node_tree, context=self.variable_context)
+            self.config_root = self.config_root_class(
+                value=self.config_dict,
+                value_node=node_tree,
+                context=self.context,
+                variables=self.variables,
+            )
 
     @property
     def errors(self):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -66,6 +66,7 @@ def test_dict_error_propogation():
     assert len(loader.config_root.foo._get_descendants_errors()) == 0
     assert len(loader.config_root.foo._get_all_errors()) == 1
 
+
 def test_valid_as_dict():
     value = "{ 'foo': 'bar'}"
     loader = DummyLoader(value)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,0 +1,78 @@
+import pytest
+
+from configyaml.config.nodes import StringNode, BoolNode
+from .test_loader import DummyLoader
+
+
+def test_variable_match():
+    n = StringNode(value='$var', variables={'var': 'testing'})
+    assert n.is_valid()
+    assert n._value == 'testing'
+
+
+def test_variable_no_match():
+    n = StringNode(value='$$var', variables={'var': 'testing'})
+    assert not n.is_valid()
+    assert n._value == '$$var'
+    assert n._errors[0].title == 'Variable not found'
+
+
+def test_variable_escaped():
+    n = StringNode(value='\$var', variables={'var': 'testing'})
+    assert n.is_valid()
+    assert n._value == '$var'
+
+
+def test_variable_case_sensitive():
+    n = StringNode(value='$VAR', variables={'var': 'testing'})
+    assert not n.is_valid()
+    assert n._value == '$VAR'
+    assert n._errors[0].title == 'Variable not found'
+
+    n = StringNode(value='$vaR', variables={'vaR': 'testing'})
+    assert n.is_valid()
+    assert n._value == 'testing'
+
+
+def test_no_variables():
+    n = StringNode(value='$var')
+    assert n.is_valid()
+    assert n._value == '$var'
+
+
+def test_variables_type_error():
+    with pytest.raises(TypeError):
+        StringNode(value='$var', variables='testing')
+
+
+def test_bool_node_variable():
+    n = BoolNode(value='$test', variables={'test': True})
+    assert n.is_valid()
+    assert n._value == True
+
+
+def test_bool_node_variable_bad_type():
+    n = BoolNode(value='$test', variables={'test': 'ok'})
+    assert not n.is_valid()
+    assert n._value == 'ok'
+
+
+def test_loader_with_variables():
+    value = "{ 'foo': '$bar'}"
+    loader = DummyLoader(value, variables={'bar': 'testing'})
+    assert loader.is_valid()
+    assert loader.as_dict()['config'] == {'foo': {'value': 'testing'}}
+
+
+def test_loader_with_missing_variable():
+    value = "{ 'foo': '$bar'}"
+    loader = DummyLoader(value, variables={'boo': 'testing'})
+    assert not loader.is_valid()
+    assert loader.errors[0].title == 'Variable not found'
+    assert loader.as_text() == """{ 'foo': '$bar'}
+# { 'foo': '$bar'}
+#     ^^^^^^
+# --------
+# Variable not found
+# - 'bar' was not found in ['boo']
+# --------"""

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,13 +1,16 @@
 import pytest
 
 from configyaml.config.nodes import StringNode, BoolNode
-from .test_loader import DummyLoader
+from .test_loader import DummyLoader, DummyComplexLoader
 
 
 def test_variable_match():
     n = StringNode(value='$var', variables={'var': 'testing'})
     assert n.is_valid()
     assert n._value == 'testing'
+
+    assert n._as_dict() == {'value': 'testing'}
+    assert n._as_dict(redact=True) == {'value': '[REDACTED]', 'redacted': True}
 
 
 def test_variable_no_match():
@@ -16,11 +19,42 @@ def test_variable_no_match():
     assert n._value == '$$var'
     assert n._errors[0].title == 'Variable not found'
 
+    assert n._as_dict() == {
+        'errors': [
+            {
+                'description': "'$var' was not found in ['var']",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'Variable not found',
+            }
+        ],
+        'value': '$$var',
+    }
+
+    assert n._as_dict(redact=True) == {
+        'errors': [
+            {
+                'description': "'$var' was not found in ['var']",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'Variable not found',
+            }
+        ],
+        'value': '$$var',
+    }
+
 
 def test_variable_escaped():
     n = StringNode(value='\$var', variables={'var': 'testing'})
     assert n.is_valid()
     assert n._value == '$var'
+
+    assert n._as_dict() == {'value': '$var'}
+    assert n._as_dict(redact=True) == {'value': '$var'}
 
 
 def test_variable_case_sensitive():
@@ -29,15 +63,74 @@ def test_variable_case_sensitive():
     assert n._value == '$VAR'
     assert n._errors[0].title == 'Variable not found'
 
+    assert n._as_dict() == {
+        'errors': [
+            {
+                'description': "'VAR' was not found in ['var']",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'Variable not found',
+            }
+        ],
+        'value': '$VAR',
+    }
+
+    assert n._as_dict(redact=True) == {
+        'errors': [
+            {
+                'description': "'VAR' was not found in ['var']",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'Variable not found',
+            }
+        ],
+        'value': '$VAR',
+    }
+
     n = StringNode(value='$vaR', variables={'vaR': 'testing'})
     assert n.is_valid()
     assert n._value == 'testing'
 
+    assert n._as_dict() == {'value': 'testing'}
+    assert n._as_dict(redact=True) == {'value': '[REDACTED]', 'redacted': True}
+
 
 def test_no_variables():
     n = StringNode(value='$var')
-    assert n.is_valid()
+    assert not n.is_valid()
     assert n._value == '$var'
+
+    assert n._as_dict() == {
+        'errors': [
+            {
+                'description': "'var' was not found in []",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'Variable not found',
+            }
+        ],
+        'value': '$var',
+    }
+
+    assert n._as_dict(redact=True) == {
+        'errors': [
+            {
+                'description': "'var' was not found in []",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'Variable not found',
+            }
+        ],
+        'value': '$var',
+    }
 
 
 def test_variables_type_error():
@@ -50,18 +143,58 @@ def test_bool_node_variable():
     assert n.is_valid()
     assert n._value == True
 
+    assert n._as_dict() == {'value': True}
+    assert n._as_dict(redact=True) == {'value': '[REDACTED]', 'redacted': True}
+
 
 def test_bool_node_variable_bad_type():
     n = BoolNode(value='$test', variables={'test': 'ok'})
     assert not n.is_valid()
     assert n._value == 'ok'
 
+    assert n._as_dict() == {
+        'errors': [
+            {
+                'description': "boolnode must be a bool",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'boolnode has an invalid type',
+            }
+        ],
+        'value': 'ok',
+    }
+
+    assert n._as_dict(redact=True) == {
+        'errors': [
+            {
+                'description': "boolnode must be a bool",
+                'end_column': None,
+                'end_line': None,
+                'start_column': None,
+                'start_line': None,
+                'title': 'boolnode has an invalid type',
+            }
+        ],
+        'value': '[REDACTED]',
+        'redacted': True,
+    }
+
 
 def test_loader_with_variables():
     value = "{ 'foo': '$bar'}"
     loader = DummyLoader(value, variables={'bar': 'testing'})
     assert loader.is_valid()
-    assert loader.as_dict()['config'] == {'foo': {'value': 'testing'}}
+
+    assert loader.as_text() == "{ 'foo': '$bar'}"
+    assert loader.as_dict() == {
+        'config': {'foo': {'value': 'testing'}}, 'config_text': "{ 'foo': '$bar'}"
+    }
+    assert loader.as_dict(redact=True) == {
+        'config': {'foo': {'redacted': True, 'value': '[REDACTED]'}},
+        'config_text': "{ 'foo': '$bar'}",
+    }
 
 
 def test_loader_with_missing_variable():
@@ -69,6 +202,7 @@ def test_loader_with_missing_variable():
     loader = DummyLoader(value, variables={'boo': 'testing'})
     assert not loader.is_valid()
     assert loader.errors[0].title == 'Variable not found'
+
     assert loader.as_text() == """{ 'foo': '$bar'}
 # { 'foo': '$bar'}
 #     ^^^^^^
@@ -76,3 +210,161 @@ def test_loader_with_missing_variable():
 # Variable not found
 # - 'bar' was not found in ['boo']
 # --------"""
+
+    assert loader.as_dict() == {
+        'config': {
+            'foo': {
+                'errors': [
+                    {
+                        'description': "'bar' was not found in ['boo']",
+                        'end_column': 15,
+                        'end_line': 0,
+                        'start_column': 9,
+                        'start_line': 0,
+                        'title': 'Variable not found',
+                    }
+                ],
+                'value': '$bar',
+            }
+        },
+        'config_text': "{ 'foo': '$bar'}",
+        'errors': [
+            {
+                'description': "'bar' was not found in ['boo']",
+                'end_column': 15,
+                'end_line': 0,
+                'start_column': 9,
+                'start_line': 0,
+                'title': 'Variable not found',
+            }
+        ],
+    }
+    assert loader.as_dict(redact=True) == {
+        'config': {
+            'foo': {
+                'errors': [
+                    {
+                        'description': "'bar' was not found in ['boo']",
+                        'end_column': 15,
+                        'end_line': 0,
+                        'start_column': 9,
+                        'start_line': 0,
+                        'title': 'Variable not found',
+                    }
+                ],
+                'value': '$bar',
+            }
+        },
+        'config_text': "{ 'foo': '$bar'}",
+        'errors': [
+            {
+                'description': "'bar' was not found in ['boo']",
+                'end_column': 15,
+                'end_line': 0,
+                'start_column': 9,
+                'start_line': 0,
+                'title': 'Variable not found',
+            }
+        ],
+    }
+
+
+def test_loader_with_nested_variables():
+    value = 'foo: $list_var\nbar: yay'
+    variables = {'list_var': ['one', 'two', '$three_var'], 'three_var': 'THREE!'}
+    loader = DummyComplexLoader(value, variables=variables)
+    assert loader.is_valid()
+
+    assert loader.as_text() == 'foo: $list_var\nbar: yay'
+    assert loader.as_dict() == {
+        'config': {
+            'bar': {'value': 'yay'},
+            'foo': {'items': [{'value': 'one'}, {'value': 'two'}, {'value': 'THREE!'}]},
+        },
+        'config_text': 'foo: $list_var\nbar: yay',
+    }
+    assert loader.as_dict(redact=True) == {
+        'config': {
+            'bar': {'value': 'yay'}, 'foo': {'redacted': True, 'value': '[REDACTED]'}
+        },
+        'config_text': 'foo: $list_var\nbar: yay',
+    }
+
+
+def test_loader_with_nested_list_variable_missing():
+    value = 'foo: $list_var\nbar: yay'
+    variables = {
+        'list_var': ['one', 'two', '$three_var'], 'threeve': 'THREE!'  # one key
+    }
+    loader = DummyComplexLoader(value, variables=variables)
+    assert not loader.is_valid()
+
+    text = loader.as_text()
+    assert text == """foo: $list_var
+# foo: $list_var
+# ^^^^^^^^^
+# --------
+# Variable not found
+# - 'three_var' was not found in ['list_var', 'threeve']
+# --------
+bar: yay"""
+
+    # the variable content should not be visible, only the variable keys
+    assert '$three_var' not in text
+
+    assert loader.as_dict() == {
+        'config': {
+            'bar': {'value': 'yay'},
+            'foo': {
+                'items': [
+                    {'value': 'one'},
+                    {'value': 'two'},
+                    {
+                        'errors': [
+                            {
+                                'description': "'three_var' was not "
+                                'found in '
+                                "['list_var', "
+                                "'threeve']",
+                                'end_column': 14,
+                                'end_line': 0,
+                                'start_column': 5,
+                                'start_line': 0,
+                                'title': 'Variable not found',
+                            }
+                        ],
+                        'value': '$three_var',
+                    },
+                ]
+            },
+        },
+        'config_text': 'foo: $list_var\nbar: yay',
+        'errors': [
+            {
+                'description': "'three_var' was not found in ['list_var', "
+                "'threeve']",
+                'end_column': 14,
+                'end_line': 0,
+                'start_column': 5,
+                'start_line': 0,
+                'title': 'Variable not found',
+            }
+        ],
+    }
+    assert loader.as_dict(redact=True) == {
+        'config': {
+            'bar': {'value': 'yay'}, 'foo': {'redacted': True, 'value': '[REDACTED]'}
+        },
+        'config_text': 'foo: $list_var\nbar: yay',
+        'errors': [
+            {
+                'description': "'three_var' was not found in ['list_var', "
+                "'threeve']",
+                'end_column': 14,
+                'end_line': 0,
+                'start_column': 5,
+                'start_line': 0,
+                'title': 'Variable not found',
+            }
+        ],
+    }


### PR DESCRIPTION
I took a stab at adding support for variables. The idea would be that in environments where config files are managed at scale, you can have the ability to pass in variables (e.g. from an organization level) to simplify the process of managing/updating config settings. This is also potentially useful if you want to store "secret" config settings outside of the file/repository itself, but you'd still have to be careful about how those secrets flow through...

My thought was that you could leave it fairly open-ended, allowing any field value to be a variable. In practice, I think you'd probably pull a JSON string from db/storage, load it in python, then pass the variables in when creating your config loader (`loader = ConfigLoader(content, variables=variables)`).

Right now it:
- expects variables to be prefixed with `$` in yaml -- `field_name: $variable_name`
- will add an error if the given variable is not found
- if a user wants to use a string that starts with a `$`, then they have to escape it `\$` and we then remove the forward slash when using the actual value -- `\$string` gets used as `$string`

There's probably some overlap with "context", which isn't being used very much and originated from a different purpose. That and a few other things could probably use some rethinking/refactoring at some point...feels like the implementation of this is clearer now than where it started (which was for a project that was going to do a lot of jinja templating type stuff -- that's why it has `context` and prefixes a lot of things with `_`).

Does this seem like an ok way to go about it? Any potential conflicts you can see? Or other ideas for syntax/usage that would be cleaner?